### PR TITLE
fix: pdoc3 can't find readme when module is in site packages

### DIFF
--- a/xsettings/__init__.py
+++ b/xsettings/__init__.py
@@ -1,7 +1,3 @@
-"""
-.. include:: ../README.md
-"""
-
 from .settings import Settings
 from .fields import SettingsField
 from .env_settings import EnvVarSettings


### PR DESCRIPTION
Don't really need this anymore anyway...